### PR TITLE
6.x 1.x dev

### DIFF
--- a/lib/Drupal/resque/LockPlugin.php
+++ b/lib/Drupal/resque/LockPlugin.php
@@ -2,37 +2,46 @@
 /**
  * @file
  * Contains Drupal\resque\PerformLockPlugin.
+ *
+ * Provides a resource lock for the Resque Job Perform function.
  */
 
 namespace Drupal\resque;
 
-use Resque as Php_Resque;
-use Resque_Job;
+use \Resque as Php_Resque;
+use \Resque_Job;
+use \Resque_Job_DontPerform;
 
+/**
+ * Provides semaphore-like behavior for Reque Jobs, by using the event hooks.
+ */
 class LockPlugin {
-
   /**
    * Check if the job can acquire the processing lock.
    *
-   * @param object $job
-   *   The resque job
+   * This will requeue the given job upon failure, if the requeue parameter is
+   * set to true.
+   *
+   * @param Resque_Job $job
+   *   The resque job.
    *
    * @return bool
-   *   True, if the job was acquired, else false and requeue the job.
+   *   If the job was acquired.
+   *
+   * @throws Resque_Job_DontPerform
    */
   public static function beforePerform(Resque_Job $job) {
-    if (Php_Resque::redis()->exists($job->payload['args'][0]['drupal_unique_key'])) {
-      if ($job->payload['args'][0]['requeue']) {
-        Php_Resque::enqueue($job->queue, $job->payload['class'], $job->payload['args'][0], TRUE);
-        return FALSE;
-      }
-      else {
-        return FALSE;
-      }
+    if (Php_Resque::redis()->setnx($job->payload['args'][0]['drupal_unique_key'], '1')) {
+      return TRUE;
     }
     else {
-      Php_Resque::redis()->set($job->payload['args'][0]['drupal_unique_key'], '1');
-      return TRUE;
+      if ($job->payload['args'][0]['requeue']) {
+        Php_Resque::enqueue($job->queue, $job->payload['class'], $job->payload['args'][0], TRUE);
+        throw new Resque_Job_DontPerform;
+      }
+      else {
+        throw new Resque_Job_DontPerform;
+      }
     }
   }
 

--- a/lib/Drupal/resque/LockPlugin.php
+++ b/lib/Drupal/resque/LockPlugin.php
@@ -37,10 +37,10 @@ class LockPlugin {
     else {
       if ($job->payload['args'][0]['requeue']) {
         Php_Resque::enqueue($job->queue, $job->payload['class'], $job->payload['args'][0], TRUE);
-        throw new Resque_Job_DontPerform;
+        throw new Resque_Job_DontPerform();
       }
       else {
-        throw new Resque_Job_DontPerform;
+        throw new Resque_Job_DontPerform();
       }
     }
   }

--- a/lib/Drupal/resque/LockUnique.php
+++ b/lib/Drupal/resque/LockUnique.php
@@ -6,11 +6,22 @@
 
 namespace Drupal\resque;
 
-use Resque as Php_Resque;
+use \Resque as Php_Resque;
 
+/**
+ * Defines the LockUnique functionality.
+ */
 class LockUnique extends Resque {
   /**
-   * {@inheritdoc}
+   * Create a unique item to be processed serially with PHP Resque.
+   *
+   * @param string $key
+   *   The key to lock the job with.
+   * @param array $data
+   *   The Resque_Job data.
+   *
+   * @return string
+   *   The status for enqueuing a Resque_Job.
    */
   public function createUniqueItem($key, $data) {
     // Check to see if class name was specified in the data array.

--- a/resque.info
+++ b/resque.info
@@ -1,4 +1,13 @@
-name = Resque
+name = "Resque"
 description = Resque queue backend.
-core = 7.x
-dependencies[] = xautoload
+version = 6.x-1.x
+core = 6.x
+files[] = lib/Drupal/resque/Base.php
+files[] = lib/Drupal/resque/Bootstrap.php
+files[] = lib/Drupal/resque/Job.php
+files[] = lib/Drupal/resque/JobInterface.php
+files[] = lib/Drupal/resque/Resque.php
+files[] = lib/Drupal/resque/ResqueUnique.php
+files[] = lib/Drupal/resque/UniquePlugin.php
+files[] = lib/Drupal/resque/LockUnique.php
+files[] = lib/Drupal/resque/LockPlugin.php


### PR DESCRIPTION
Fixing incorrect .info file carried over from the 7.x branch. Changed the key acquisition to use the redis function setnx, which behaves more like a semaphore. Updated documentation and fixed the handling of de/requeuing a job in the beforePerform function call.
